### PR TITLE
Update to Blazor WebAssembly 3.2.0 release

### DIFF
--- a/App.razor
+++ b/App.razor
@@ -1,1 +1,10 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" />
+﻿<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/CSharpMinifierDemo.csproj
+++ b/CSharpMinifierDemo.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RestoreAdditionalProjectSources>
-      https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
-      https://dotnet.myget.org/F/blazor-dev/api/v3/index.json;
-    </RestoreAdditionalProjectSources>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
@@ -16,10 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="CSharpMinifier" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview5-19227-01" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview5-19227-01" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview5-19227-01" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -23,15 +23,16 @@
     }
 </div>
 
-<textarea bind-value-oninput=@_input
-          onkeyup=@(_ => Minify())
-          ref="_inputTextArea"
+<textarea @bind=@_input
+          @bind:event="oninput"
+          @onkeyup=@(_ => Minify())
+          @ref="_inputTextArea"
           autofocus wrap="off"
           placeholder="Enter/Paste some C# valid code here to minify"></textarea>
 
 <textarea readonly
           class="@(_error ? "syntax-error" : null)"
-          bind=@_output></textarea>
+          @bind=@_output></textarea>
 
 @functions
 {
@@ -43,12 +44,13 @@
     string _hash;
     bool _error;
     TimeSpan? _ms;
-    ElementRef _inputTextArea;
+    ElementReference _inputTextArea;
 
-    protected override async Task OnAfterRenderAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await base.OnAfterRenderAsync();
-        await JSRuntime.InvokeAsync<object>("$onpaste", _inputTextArea, new DotNetObjectRef(this));
+        await base.OnAfterRenderAsync(firstRender);
+        if (firstRender)
+            await JSRuntime.InvokeAsync<object>("$onpaste", _inputTextArea, DotNetObjectReference.Create(this));
     }
 
     [JSInvokable]

--- a/Program.cs
+++ b/Program.cs
@@ -1,30 +1,20 @@
 ﻿namespace CSharpMinifierDemo
 {
-    using System.Linq;
-    using Microsoft.AspNetCore.Blazor.Hosting;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Components.Builder;
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
     using Microsoft.Extensions.DependencyInjection;
 
     static class Program
     {
-        public static void Main(string[] args) =>
-            CreateHostBuilder(args).Build().Run();
-
-        public static IWebAssemblyHostBuilder CreateHostBuilder(string[] args) =>
-            BlazorWebAssemblyHost
-                .CreateDefaultBuilder()
-                .UseBlazorStartup<Startup>();
-    }
-
-    public sealed class Startup
-    {
-        public void ConfigureServices(IServiceCollection services) =>
-            services.AddResponseCompression(options =>
-                options.MimeTypes.Append("application/octet-stream")
-                                 .Append("application/wasm"));
-
-        public void Configure(IComponentsApplicationBuilder app) =>
-            app.AddComponent<App>("app");
+        public static async Task Main(string[] args)
+        {
+            var builder = WebAssemblyHostBuilder.CreateDefault(args);
+            builder.RootComponents.Add<App>("app");
+            var baseUrl = new Uri(builder.HostEnvironment.BaseAddress);
+            builder.Services.AddTransient(sp => new HttpClient { BaseAddress = baseUrl });
+            await builder.Build().RunAsync();
+        }
     }
 }

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -1,7 +1,9 @@
 @using System.Net.Http
+@using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
-@using Microsoft.AspNetCore.Components.Layouts
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using CSharpMinifierDemo
 @using CSharpMinifierDemo.Shared

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,13 +24,12 @@ build_script:
 - ps: |
     $ErrorActionPreference = 'Stop'
     dotnet publish -c Release -o dist
-    ren "dist/$($env:APPVEYOR_PROJECT_NAME)" project
-    $indexPath = "dist/project/dist/index.html"
+    $indexPath = "dist/wwwroot/index.html"
     $index = Get-Content -Raw $indexPath
     $index = $index -replace '(?<=<base\s+href\s*=\s*")/(?=")', "/$($env:APPVEYOR_PROJECT_NAME)/"
     Set-Content $indexPath $index -Encoding Ascii -NoNewline
 artifacts:
-- path: dist/project/dist
+- path: dist/wwwroot
   name: dist
 deploy_script:
 - ps: |
@@ -44,7 +43,7 @@ deploy_script:
     git config --global user.email $env:github_email
     git config --global user.name "Atif Aziz"
     git worktree add -b gh-pages ../io origin/gh-pages
-    robocopy /s /purge dist/project/dist ../io /xd .* /xf .* /xf 4??.html
+    robocopy /s /purge dist/wwwroot ../io /xd .* /xf .* /xf 4??.html
     cd ../io
     $ErrorActionPreference = 'Continue' # ignore warnings about EOLs
     git add .

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100-preview5-011568"
+    "version": "3.1.300"
   }
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -25,8 +25,10 @@
     </app>
     <script>
 function $onpaste(e, dotnet) {
-    e.addEventListener('paste', () =>
-        setTimeout(() => dotnet.invokeMethodAsync('OnPaste', e.value), 0));
+    e.addEventListener('paste', () => {
+        console.log('onpaste');
+         return setTimeout(() => dotnet.invokeMethodAsync('OnPaste', e.value), 0);
+    });
 }
     </script>
     <script src="_framework/blazor.webassembly.js"></script>


### PR DESCRIPTION
This PR updates the project to use [Blazor WebAssembly 3.2.0 release](https://devblogs.microsoft.com/aspnet/blazor-webassembly-3-2-0-now-available/).